### PR TITLE
feat: Atualizar URL do perfil e melhorar exibição do link

### DIFF
--- a/pages/my-page.vue
+++ b/pages/my-page.vue
@@ -22,8 +22,7 @@
             <div class="d-flex flex-column">
               <div class="text-h6 font-weight-bold">{{ userAlias }}</div>
               <div class="text-body-2 grey--text d-flex align-center">
-                <v-icon small class="mr-1">mdi-link</v-icon>
-                <span class="text-truncate">{{ profileUrl }}</span>
+                <a :href="profileUrl" target="_blank" class="text-truncate">{{ profileUrl }}</a>
               </div>
             </div>
           </v-col>
@@ -157,7 +156,7 @@ export default {
       return this.$store.state.auth.user?.id;
     },
     profileUrl() {
-      return `${window.location.origin}/p/${this.userAlias}`;
+      return `https://vitrine.meuingresso.com.br/produtores/${this.userAlias}`;
     },
     getStatistics() {
       return [
@@ -211,7 +210,7 @@ export default {
         }));
 
         const userAttachments = this.$store.getters['userDocuments/$userAttachments'];
-        const userInfo = this.$store.getters['user/$user'];
+        const userInfo = this.$auth.user;
 
         const bioDoc = userAttachments.find(doc => doc.name === 'biography');
         const profileImageDoc = userAttachments.find(doc => doc.name === 'profile_image');


### PR DESCRIPTION
- Alterada a forma de exibir a URL do perfil, agora utilizando um link clicável.
- Atualizada a lógica para gerar a URL do perfil, apontando para o domínio correto.
- Modificada a forma de acessar as informações do usuário, utilizando a propriedade $auth em vez de getters do Vuex.