### PR TITLE
feat: Atualizar validação do preço no formulário de ingresso

### DIFF
--- a/components/molecules/TicketForm.vue
+++ b/components/molecules/TicketForm.vue
@@ -312,8 +312,8 @@ export default {
         price: [
           (v) => !!v || 'O preço é obrigatório.',
           (v) =>
-            parseFloat(v.replace(',', '.')) >= 0 ||
-            'O preço deve ser maior ou igual a zero.',
+            parseFloat(v.replace(',', '.')) >= 3 ||
+            'O preço deve ser maior ou igual a R$3,00.',
         ],
         total_quantity: [
           (v) => !!v || 'A quantidade é obrigatória.',


### PR DESCRIPTION
- Modificada a regra de validação do campo de preço para exigir um valor mínimo de R$3,00, garantindo que os preços sejam adequados.