### PR TITLE
feat: Atualizar rótulos e cálculos de valores no modal de detalhes de…

### DIFF
--- a/components/organisms/payment/PaymentDetailsModal.vue
+++ b/components/organisms/payment/PaymentDetailsModal.vue
@@ -1,5 +1,6 @@
 <template>
-  <v-dialog :value="show" max-width="960px" :fullscreen="isMobile" persistent content-class="secondary-dialog"
+  <v-dialog
+:value="show" max-width="960px" :fullscreen="isMobile" persistent content-class="secondary-dialog"
     @input="$emit('update:show', $event)">
     <v-card :tile="isMobile">
       <v-card-title class="d-flex justify-space-between align-center">
@@ -57,7 +58,7 @@
                 </div>
               </v-col>
               <v-col cols="6">
-                <div class="info-label">Valor bruto</div>
+                <div class="info-label">Valor total</div>
                 <div class="info-value">{{ formatRealValue(payment.gross_value) }}</div>
               </v-col>
               <v-col cols="6">
@@ -68,7 +69,7 @@
               </v-col>
               <v-col cols="6">
                 <div class="info-label">
-                  Valor total
+                  Valor pago
 
                   <v-tooltip bottom>
                     <template #activator="{ on, attrs }">
@@ -85,11 +86,11 @@
               </v-col>
               <v-col cols="6">
                 <div class="info-label">Taxa</div>
-                <div class="info-value">{{ getEventFeePercentage }}%</div>
+                <div class="info-value">{{ formatRealValue(getOrderFee) }}</div>
               </v-col>
               <v-col cols="6">
                 <div class="info-label">
-                  Valor líquido
+                  Valor a receber
 
                   <v-tooltip bottom>
                     <template #activator="{ on, attrs }">
@@ -135,7 +136,8 @@
                       <v-tooltip bottom>
                         <template #activator="{ on, attrs }">
                           <div v-bind="attrs" v-on="on">
-                            <v-btn x-small :disabled="!is24HoursOrMoreBeforeEventStart" icon color="primary"
+                            <v-btn
+x-small :disabled="!is24HoursOrMoreBeforeEventStart" icon color="primary"
                               @click="openTicketEditModal(ticket)">
                               <v-icon small>mdi-pencil</v-icon>
                             </v-btn>
@@ -156,15 +158,18 @@
           <v-divider />
           <div class="tickets-actions d-flex align-center justify-space-between mt-4">
             <div class="d-flex align-center">
-              <ButtonWithIcon text="Cancelar pedido" outlined color="error" :loading="isCancelling" icon="mdi-cancel"
+              <ButtonWithIcon
+text="Cancelar pedido" outlined color="error" :loading="isCancelling" icon="mdi-cancel"
                 class="ml-2" @click="showCancelConfirmation" />
             </div>
 
             <div class="d-flex justify-end">
-              <ButtonWithIcon text="Reenviar ingressos" outlined :loading="isResending" icon="mdi-email" class="mr-2"
+              <ButtonWithIcon
+text="Reenviar ingressos" outlined :loading="isResending" icon="mdi-email" class="mr-2"
                 @click="resendTickets" />
 
-              <ButtonWithIcon text="Imprimir ingressos" outlined :loading="isPrinting" icon="mdi-printer"
+              <ButtonWithIcon
+text="Imprimir ingressos" outlined :loading="isPrinting" icon="mdi-printer"
                 @click="generatePDF" />
             </div>
           </div>
@@ -173,11 +178,13 @@
     </v-card>
 
     <!-- Modal de Edição de Campos do Ingresso -->
-    <TicketFieldsEditModal :show="showTicketFieldsEditModal" :customer-ticket-id="selectedTicketId"
+    <TicketFieldsEditModal
+:show="showTicketFieldsEditModal" :customer-ticket-id="selectedTicketId"
       @update:show="showTicketFieldsEditModal = $event" @fields-updated="handleTicketFieldsUpdated" />
 
     <!-- Modal de Confirmação de Cancelamento -->
-    <ConfirmDialog v-model="showCancelDialog" title="Cancelar Pedido"
+    <ConfirmDialog
+v-model="showCancelDialog" title="Cancelar Pedido"
       message="Tem certeza que deseja cancelar este pedido? Esta ação não pode ser desfeita."
       confirm-text="Sim, cancelar" cancel-text="Não, voltar" confirm-color="error" :loading="isCancelling"
       @cancel="showCancelDialog = $event" @confirm="cancelOrder" />
@@ -271,6 +278,13 @@ export default {
       // O netValue já inclui a taxa, então precisamos calcular o valor original
       // Fórmula: valorOriginal = valorComTaxa / (1 + taxa/100)
       return fee > 0 ? netValue / (1 + fee / 100) : netValue;
+    },
+
+    // retorna a comissão da plataforma
+    // Valor pago * taxa do evento
+    getOrderFee() {
+      if (!this.payment?.event) return 0;
+      return this.getTotalValue * (this.getEventFeePercentage / 100);
     },
   },
 

--- a/pages/payment/details/_orderId.vue
+++ b/pages/payment/details/_orderId.vue
@@ -76,7 +76,7 @@
                   </v-row>
                   <v-row>
                     <v-col cols="12" md="6">
-                      <div class="info-label font-weight-bold">Valor bruto</div>
+                      <div class="info-label font-weight-bold">Valor total</div>
                       <div class="info-value">
                         {{ formatRealValue(payment.gross_value) }}
                       </div>
@@ -91,7 +91,7 @@
                   <v-row>
                     <v-col cols="12" md="6">
                       <div class="info-label font-weight-bold">
-                        Valor total
+                        Valor pago
 
                         <v-tooltip bottom>
                           <template #activator="{ on, attrs }">
@@ -108,13 +108,15 @@
                     </v-col>
                     <v-col cols="12" md="6">
                       <div class="info-label font-weight-bold">Taxa</div>
-                      <div class="info-value">{{ getEventFee }}%</div>
+                      <div class="info-value">
+                        {{ formatRealValue(getOrderFee) }}
+                      </div>
                     </v-col>
                   </v-row>
                   <v-row>
                     <v-col cols="12" md="6">
                       <div class="info-label font-weight-bold">
-                        Valor líquido
+                        Valor a receber
 
                         <v-tooltip bottom>
                           <template #activator="{ on, attrs }">
@@ -449,6 +451,13 @@ export default {
       return this.payment.payment_method !== "PDV"
         ? this.payment.event?.fees?.platform_fee || 0
         : 0;
+    },
+
+    // retorna a comissão da plataforma
+    // Valor pago * taxa do evento
+    getOrderFee() {
+      if (!this.payment?.event) return 0;
+      return this.getTotalValue * (this.getEventFee / 100);
     },
 
     isLoading() {


### PR DESCRIPTION
… pagamento

- Alterados rótulos de "Valor bruto" para "Valor total" e "Valor líquido" para "Valor a receber" para maior clareza.
- Atualizada a exibição do valor da taxa e do valor pago, utilizando a nova função getOrderFee para calcular a comissão da plataforma.
- Melhorada a formatação do código para maior legibilidade.